### PR TITLE
feat: add dev mode config support

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,8 @@ type Options struct {
 	Namespace       string
 	Threadiness     int
 	HTTPSListenPort int
+	DevMode         bool
+	DevURL          string
 
 	ControllerUsername        string
 	GarbageCollectionUsername string

--- a/pkg/server/admission/admission.go
+++ b/pkg/server/admission/admission.go
@@ -2,6 +2,7 @@ package admission
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -123,10 +124,9 @@ func (v *Handler) admit(response *webhook.Response, req *Request) error {
 
 	if err != nil {
 		var admitErr werror.AdmitError
-		if e, ok := err.(werror.AdmitError); ok {
+		var e werror.AdmitError
+		if errors.As(err, &e) {
 			admitErr = e
-		} else {
-			admitErr = werror.NewInternalError(err.Error())
 		}
 		response.Allowed = false
 		response.Result = admitErr.AsResult()


### PR DESCRIPTION
**Description:**
Allowing users to run webhook in local dev mode via passing the following configs(e.g.,):
- `DevMode: true`
- `DevURL: "tcp://8.tcp.ngrok.io:13634"`